### PR TITLE
修复JSON表格列数据错位

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "json-log-viewer",
-	"version": "0.0.1",
+	"version": "1.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "json-log-viewer",
-			"version": "0.0.1",
+			"version": "1.0.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"json5": "^2.2.0",

--- a/src/jsonTable.ts
+++ b/src/jsonTable.ts
@@ -8,11 +8,22 @@ import * as vscode from 'vscode';
 export class JSONTable {
     private titleJson: object = {};
     private contentList: object[] = [];
+    private keys: string[] = []; // 新增：用于存储固定的键顺序
 
     constructor(text: string) {
         try {
             const lines = text.trim().split("\n");
             this.contentList = [];
+            
+            // 先解析第一行来确定键的顺序
+            if (lines.length > 0) {
+                let firstJson = JSON5.parse(lines[0].trim());
+                this.titleJson = firstJson;
+                // 保存键的顺序
+                this.keys = Object.keys(firstJson);
+            }
+
+            // 然后解析所有行
             for (let i = 0; i < lines.length; i++) {
                 let tempStr = lines[i].trim();
                 if ("" === tempStr) {
@@ -21,7 +32,6 @@ export class JSONTable {
                 let tempJson = JSON5.parse(tempStr);
                 this.contentList.push(tempJson);
             }
-            this.titleJson = JSON5.parse(lines[0]);
         } catch (e) {
             console.log(e);
             throw e;
@@ -88,7 +98,8 @@ export class JSONTable {
 
     getTitle(): string {
         let result = "<tr>";
-        for (let key in this.titleJson) {
+        // 使用保存的键顺序来生成表头
+        for (let key of this.keys) {
             let temp = `<th>${key}<div class="resizer"></div></th>`;
             result += temp;
         }
@@ -100,7 +111,8 @@ export class JSONTable {
         for (let i = 0; i < this.contentList.length; i++) {
             const content: any = this.contentList[i];
             result += "<tr>";
-            for (let key in content) {
+            // 使用保存的键顺序来生成每一行的数据
+            for (let key of this.keys) {
                 if (typeof content[key] === 'object' && content[key] !== null) {
                     result += `<td>${JSON.stringify(content[key], null, 4)}</td>`;
                 } else {


### PR DESCRIPTION
修复JSON表格列数据错位

JSON 的key顺序不一致时，表格错位
比如以下日志内容：
```
{"key_a": "a_1", "key_b":"b_1"}
{"key_b":"b_2", "key_a": "a_2"}
```

```
key_a    key_b
a_1      b_1
b_2      a_2    // 数据错位
```

期望结果：
```
key_a    key_b
a_1      b_1
a_2      b_2    // 正确对应
```

解决内容：
改jsonTable.ts
加 keys 数组属性存固定的键顺序
用固定的键顺序生成表头和内容